### PR TITLE
Make some colors customizable in theme

### DIFF
--- a/src/components/Connector/index.tsx
+++ b/src/components/Connector/index.tsx
@@ -1,13 +1,10 @@
-import { useColorModeValue } from '@chakra-ui/color-mode';
 import {
   chakra,
   HTMLChakraProps,
   ThemingProps,
   useStyles,
-  useTheme,
 } from '@chakra-ui/system';
-import { getColor } from '@chakra-ui/theme-tools';
-import { motion } from 'framer-motion';
+import { dataAttr } from '@chakra-ui/utils';
 import * as React from 'react';
 
 interface ConnectorProps extends HTMLChakraProps<'div'>, ThemingProps {
@@ -18,11 +15,8 @@ interface ConnectorProps extends HTMLChakraProps<'div'>, ThemingProps {
   orientation?: 'vertical' | 'horizontal';
 }
 
-const MotionDiv = motion(chakra.div);
-
 export const Connector = React.memo(
   ({
-    colorScheme: c,
     isCompletedStep,
     isVertical,
     children,
@@ -37,16 +31,6 @@ export const Connector = React.memo(
       ...connector,
     };
 
-    const theme = useTheme();
-
-    const activeBg = useColorModeValue(`${c}.500`, `${c}.200`);
-
-    const inactiveBg = useColorModeValue(`gray.200`, `gray.700`);
-
-    const rawInitialColor = getColor(theme, inactiveBg);
-
-    const rawActiveColor = getColor(theme, activeBg);
-
     const getMargin = () => {
       if (isVertical) return `calc(${stepIconContainer.width} / 2)`;
       if (!hasLabel) return 2;
@@ -54,7 +38,7 @@ export const Connector = React.memo(
     };
 
     return (
-      <MotionDiv
+      <chakra.div
         __css={{
           ms: getMargin(),
           my: isVertical ? 2 : 0,
@@ -65,17 +49,13 @@ export const Connector = React.memo(
           borderTopWidth: isLastStep || isVertical ? 0 : '2px',
           borderInlineStartWidth: isLastStep || !isVertical ? 0 : '2px',
           minHeight: isLastStep || !isVertical ? 'auto' : '1.5rem',
+          borderColor: connector.borderColor,
           ...connectorStyles,
         }}
-        initial={{
-          borderColor: rawInitialColor,
-        }}
-        animate={{
-          borderColor: isCompletedStep ? rawActiveColor : rawInitialColor,
-        }}
+        data-highlighted={dataAttr(isCompletedStep)}
       >
         {isVertical && children}
-      </MotionDiv>
+      </chakra.div>
     );
   }
 );

--- a/src/components/Step/index.tsx
+++ b/src/components/Step/index.tsx
@@ -1,4 +1,3 @@
-import { useColorModeValue } from '@chakra-ui/color-mode';
 import { Flex } from '@chakra-ui/react';
 import { Spinner } from '@chakra-ui/spinner';
 import {
@@ -8,7 +7,8 @@ import {
   ThemingProps,
   useStyles,
 } from '@chakra-ui/system';
-import { darken, lighten, mode } from '@chakra-ui/theme-tools';
+import { dataAttr } from '@chakra-ui/utils';
+import { mode } from '@chakra-ui/theme-tools';
 import { Collapse } from '@chakra-ui/transition';
 import { AnimatePresence, motion } from 'framer-motion';
 import * as React from 'react';
@@ -120,39 +120,8 @@ export const Step = forwardRef<StepProps, 'div'>(
       ...description,
     };
 
-    const activeBg = `${c}.500`;
-
-    const inactiveBg = useColorModeValue(`gray.200`, `gray.700`);
-
     const isError = state === 'error';
     const isLoading = state === 'loading';
-
-    const getBorderColor = React.useMemo(() => {
-      if (isCompletedStep) return activeBg;
-      if (isCurrentStep) {
-        if (isError) {
-          return 'red.500';
-        }
-        return activeBg;
-      }
-      return inactiveBg;
-    }, [isError, isCompletedStep, isCurrentStep, activeBg, inactiveBg]);
-
-    const getHoverBorderColor = React.useMemo(() => {
-      if (!clickable) return getBorderColor;
-      return activeBg;
-    }, [clickable]);
-
-    const getBgColor = React.useMemo(() => {
-      if (isCompletedStep) return activeBg;
-      if (isCurrentStep) {
-        if (isError) {
-          return 'red.500';
-        }
-        return mode(darken(inactiveBg, 0.5), lighten(inactiveBg, 0.5));
-      }
-      return inactiveBg;
-    }, [isError, isCompletedStep, isCurrentStep, activeBg, inactiveBg]);
 
     const hasVisited = isCurrentStep || isCompletedStep;
 
@@ -234,14 +203,11 @@ export const Step = forwardRef<StepProps, 'div'>(
             }}
           >
             <chakra.div
-              __css={{
-                bg: getBgColor,
-                borderColor: getBorderColor,
-                _hover: {
-                  borderColor: getHoverBorderColor,
-                },
-                ...stepIconContainerStyles,
-              }}
+              __css={stepIconContainerStyles}
+              aria-current={isCurrentStep ? 'step' : undefined}
+              data-invalid={dataAttr(isCurrentStep && isError)}
+              data-highlighted={dataAttr(isCompletedStep)}
+              data-clickable={dataAttr(clickable)}
             >
               <AnimatePresence exitBeforeEnter>{renderIcon}</AnimatePresence>
             </chakra.div>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,6 +1,8 @@
 import {
   anatomy,
   mode,
+  lighten,
+  darken,
   PartsStyleFunction,
   SystemStyleFunction,
   SystemStyleObject,
@@ -22,31 +24,68 @@ const baseStyleIcon: SystemStyleObject = {
   strokeWidth: '2px',
 };
 
-const baseStyleLabel: SystemStyleFunction = props => {
+const baseStyleLabel: SystemStyleFunction = (props) => ({
+  color: mode(`gray.900`, `gray.100`)(props),
+});
+
+const baseStyleDescription: SystemStyleFunction = (props) => ({
+  color: mode(`gray.800`, `gray.200`)(props),
+});
+
+const baseStyleConnector: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props;
+  const inactiveColor = mode('gray.200', 'gray.700')(props);
+  const activeColor = mode(`${c}.500`, `${c}.200`)(props);
+
   return {
-    color: mode(`gray.900`, `gray.100`)(props),
+    borderColor: inactiveColor,
+    transitionProperty: 'border-color',
+    transitionDuration: 'normal',
+    _highlighted: {
+      borderColor: activeColor,
+    },
   };
 };
 
-const baseStyleDescription: SystemStyleFunction = props => {
+const baseStyleStepIconContainer: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props;
+  const inactiveColor = mode('gray.200', 'gray.700')(props);
+  const activeColor = `${c}.500`;
+
   return {
-    color: mode(`gray.800`, `gray.200`)(props),
+    bg: inactiveColor,
+    borderColor: inactiveColor,
+    transitionProperty: 'background, border-color',
+    transitionDuration: 'normal',
+    _activeStep: {
+      bg: mode(darken(inactiveColor, 0.5), lighten(inactiveColor, 0.5))(props),
+      borderColor: activeColor,
+      _invalid: {
+        bg: 'red.500',
+        borderColor: 'red.500',
+      },
+    },
+    _highlighted: {
+      bg: activeColor,
+      borderColor: activeColor,
+    },
+    '&[data-clickable]:hover': {
+      borderColor: activeColor,
+    },
   };
 };
 
-const baseStyle: PartsStyleFunction<typeof parts> = props => {
-  return {
-    connector: {},
-    description: baseStyleDescription(props),
-    icon: baseStyleIcon,
-    label: baseStyleLabel(props),
-    labelContainer: {},
-    step: {},
-    stepContainer: {},
-    stepIconContainer: {},
-    steps: {},
-  };
-};
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  connector: baseStyleConnector(props),
+  description: baseStyleDescription(props),
+  icon: baseStyleIcon,
+  label: baseStyleLabel(props),
+  labelContainer: {},
+  step: {},
+  stepContainer: {},
+  stepIconContainer: baseStyleStepIconContainer(props),
+  steps: {},
+});
 
 const sizes = {
   sm: {


### PR DESCRIPTION
I want to display steps on a `gray.700` background. But some colors in this package are hard-coded to `gray.700` (connector, icon container background) and they are not visible in a box with `gray.700` background:

![image](https://user-images.githubusercontent.com/2115303/140980850-5fbe246a-4e98-411d-b8ac-6d34759fd203.png)

This PR moves some styles from component code to theme, so developers can override default values.