### PR TITLE
Fixing the Step Props type 'IntrinsicAttributes & ObjectDto' problem

### DIFF
--- a/src/components/Step/index.tsx
+++ b/src/components/Step/index.tsx
@@ -18,6 +18,7 @@ export interface StepProps extends HTMLChakraProps<'div'> {
   label?: string | React.ReactNode;
   description?: string;
   icon?: React.ComponentType<any>;
+  isCompletedStep?: boolean;
 }
 
 // Props which shouldn't be passed to to the Step component from the user


### PR DESCRIPTION
Somehow the `isCompletedStep` is not being evaluated over the steps props, this will fix the IntrinsicAttributes & ObjectDto problem that might come as a result of introducing it.

Thanks for the awesome package.