### PR TITLE
refactor: export prop types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 .cache
 dist
+.idea/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Step } from './components/Step';
-export { Steps } from './components/Steps';
+export { Step, StepProps } from './components/Step';
+export { Steps, StepsProps } from './components/Steps';
 export { useSteps } from './hooks/useSteps';
 export { StepsStyleConfig } from './theme';


### PR DESCRIPTION
Inside my own chakra component library, I also need to use prop types from this library but they're not exported. I also edited `.gitignore` because I'm using Webstorm IDE and it creates some caching files, so it's good to ignore them.