### PR TITLE
refactor: add option to style iconLabel separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ If you would like to customize the appearance of the Steps component you can do 
 connector;
 description;
 icon;
+iconLabel;
 label;
 labelContainer;
 step;

--- a/src/components/StepIcon/index.tsx
+++ b/src/components/StepIcon/index.tsx
@@ -28,7 +28,7 @@ const animationConfig = {
 };
 
 export const StepIcon = forwardRef<StepIconProps, 'div'>((props, ref) => {
-  const { icon, label } = useStyles();
+  const { icon, iconLabel, label } = useStyles();
 
   const {
     isCompletedStep,
@@ -93,6 +93,7 @@ export const StepIcon = forwardRef<StepIconProps, 'div'>((props, ref) => {
       <AnimatedSpan
         ref={ref}
         key="label"
+        style={iconLabel}
         __css={labelStyles}
         {...animationConfig}
       >

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -12,6 +12,7 @@ const parts = anatomy('steps').parts(
   'connector',
   'description',
   'icon',
+  'iconLabel',
   'label',
   'labelContainer',
   'step',
@@ -91,6 +92,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = props => ({
   connector: baseStyleConnector(props),
   description: baseStyleDescription(props),
   icon: baseStyleIcon,
+  iconLabel: baseStyleLabel(props),
   label: baseStyleLabel(props),
   labelContainer: {
     display: 'flex',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14358496/159697688-6cba002e-79a2-4237-9e7f-046fc3d9ce43.png)

Add option to style "1", "2", ... letters inside Step component when an icon is not provided. Currently, when I want to e.g. change the color of these numbers it'll also change the color of step "title" and "description".