### PR TITLE
refactor: export components types

### DIFF
--- a/chakra-ui-steps/src/index.ts
+++ b/chakra-ui-steps/src/index.ts
@@ -2,3 +2,6 @@ export { Step } from './components/Step';
 export { Steps } from './components/Steps';
 export { useSteps } from './hooks/useSteps';
 export { StepsStyleConfig } from './theme';
+
+export type { StepProps } from './components/Step';
+export type { StepsProps } from './components/Steps';


### PR DESCRIPTION
Inside my own chakra component library, I also need to use prop types from this library but they're not exported. I also edited .gitignore because I'm using Webstorm IDE and it creates some caching files, so it's good to ignore them.