### PR TITLE
Make it possible to defined checkIcon and state at each Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export const StepsExample = () => {
   });
 
   return (
-    <Flex flexDir='column' width='100%'>
+    <Flex flexDir="column" width="100%">
       <Steps activeStep={activeStep}>
         {steps.map(({ label, content }) => (
           <Step label={label} key={label}>
@@ -95,22 +95,22 @@ export const StepsExample = () => {
       </Steps>
       {activeStep === steps.length ? (
         <Flex p={4}>
-          <Button mx='auto' size='sm' onClick={reset}>
+          <Button mx="auto" size="sm" onClick={reset}>
             Reset
           </Button>
         </Flex>
       ) : (
-        <Flex width='100%' justify='flex-end'>
+        <Flex width="100%" justify="flex-end">
           <Button
             isDisabled={activeStep === 0}
             mr={4}
             onClick={prevStep}
-            size='sm'
-            variant='ghost'
+            size="sm"
+            variant="ghost"
           >
             Prev
           </Button>
-          <Button size='sm' onClick={nextStep}>
+          <Button size="sm" onClick={nextStep}>
             {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
           </Button>
         </Flex>

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 <br />
 <br />
 
-[![MIT License](https://badgen.net/github/license/jeanverster/chakra-ui-steps 'MIT License')](LICENSE.md)
-[![npm - chakra-ui-steps](https://img.shields.io/npm/v/chakra-ui-steps 'chakra-ui-steps npm')](https://www.npmjs.com/package/chakra-ui-steps)
+[![MIT License](https://badgen.net/github/license/jeanverster/chakra-ui-steps "MIT License")](LICENSE.md)
+[![npm - chakra-ui-steps](https://img.shields.io/npm/v/chakra-ui-steps "chakra-ui-steps npm")](https://www.npmjs.com/package/chakra-ui-steps)
 [![bundle size - chakra-ui-steps](https://badgen.net/bundlephobia/min/chakra-ui-steps)](https://bundlephobia.com/result?p=chakra-ui-steps)
 [![bundle size - chakra-ui-steps](https://badgen.net/bundlephobia/minzip/chakra-ui-steps)](https://bundlephobia.com/result?p=chakra-ui-steps)
-[![Total Downloads - chakra-ui-steps](https://badgen.net/npm/dt/chakra-ui-steps?color=blue 'chakra-ui-steps npm downloads')](https://www.npmjs.com/package/chakra-ui-steps)
+[![Total Downloads - chakra-ui-steps](https://badgen.net/npm/dt/chakra-ui-steps?color=blue "chakra-ui-steps npm downloads")](https://www.npmjs.com/package/chakra-ui-steps)
 
 ![screenshot](https://i.imgur.com/B9zbJEa.gif)
 
@@ -42,8 +42,8 @@ npm i chakra-ui-steps
 In order to get started you will need to extend the default Chakra theme with the provided `StepsStyleConfig` object, like so:
 
 ```jsx
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
-import { StepsStyleConfig as Steps } from 'chakra-ui-steps';
+import { ChakraProvider, extendTheme } from "@chakra-ui/react";
+import { StepsStyleConfig as Steps } from "chakra-ui-steps";
 
 const theme = extendTheme({
   components: {
@@ -65,7 +65,7 @@ Once that's done you should be good to go!
 ### Basic Example
 
 ```jsx
-import { Step, Steps, useSteps } from 'chakra-ui-steps';
+import { Step, Steps, useSteps } from "chakra-ui-steps";
 
 const content = (
   <Flex py={4}>
@@ -74,9 +74,9 @@ const content = (
 );
 
 const steps = [
-  { label: 'Step 1', content },
-  { label: 'Step 2', content },
-  { label: 'Step 3', content },
+  { label: "Step 1", content },
+  { label: "Step 2", content },
+  { label: "Step 3", content },
 ];
 
 export const StepsExample = () => {
@@ -111,7 +111,7 @@ export const StepsExample = () => {
             Prev
           </Button>
           <Button size="sm" onClick={nextStep}>
-            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+            {activeStep === steps.length - 1 ? "Finish" : "Next"}
           </Button>
         </Flex>
       )}
@@ -140,17 +140,17 @@ steps;
 The default styles for each part can be found <a href="https://github.com/jeanverster/chakra-ui-steps/blob/main/src/theme/index.ts" target="_blank">here</a>. Below is an example of how you might change the stroke width of the icons:
 
 ```js
-import { StepsStyleConfig } from 'chakra-ui-steps';
+import { StepsStyleConfig } from "chakra-ui-steps";
 
 const CustomSteps = {
   ...StepsStyleConfig,
-  baseStyle: props => {
+  baseStyle: (props) => {
     return {
       ...StepsStyleConfig.baseStyle(props),
       icon: {
         ...StepsStyleConfig.baseStyle(props).icon,
         // your custom styles here
-        strokeWidth: '1px',
+        strokeWidth: "1px",
       },
     };
   },
@@ -169,21 +169,24 @@ const theme = extendTheme({
 
 ### `Steps`
 
-| Prop                   | Type                | Required | Description                                                                | Default    |
-| ---------------------- | ------------------- | -------- | -------------------------------------------------------------------------- | ---------- |
-| **`activeStep`**       | number              | yes      | Currently active step                                                      | 0          |
-| **`colorScheme`**      | string              | no       | Sets the color accent of the Steps component show                          | green      |
-| **`orientation`**      | string              | no       | Sets the orientation of the Steps component                                | horizontal |
-| **`responsive`**       | boolean             | no       | Sets whether the component auto switches to vertical orientation on mobile | true       |
-| **`checkIcon`**        | React.ComponentType | no       | Allows you to provide a custom check icon                                  | undefined  |
-| **`onClickStep`**      | () => void          | no       | If defined, allows you to click on the step icons                          | undefined  |
-| **`labelOrientation`** | string              | no       | Switch between horizontal and vertical label orientation                   | undefined  |
+| Prop                   | Type                 | Required | Description                                                                | Default    |
+| ---------------------- | -------------------- | -------- | -------------------------------------------------------------------------- | ---------- |
+| **`activeStep`**       | number               | yes      | Currently active step                                                      | 0          |
+| **`colorScheme`**      | string               | no       | Sets the color accent of the Steps component show                          | green      |
+| **`orientation`**      | string               | no       | Sets the orientation of the Steps component                                | horizontal |
+| **`responsive`**       | boolean              | no       | Sets whether the component auto switches to vertical orientation on mobile | true       |
+| **`checkIcon`**        | React.ComponentType  | no       | Allows you to provide a custom check icon                                  | undefined  |
+| **`onClickStep`**      | () => void           | no       | If defined, allows you to click on the step icons                          | undefined  |
+| **`labelOrientation`** | string               | no       | Switch between horizontal and vertical label orientation                   | undefined  |
+| **`state`**            | 'loading' \| 'error' | no       | Let's you set the state to error or loading                                | undefined  |
 
 ### `Step`
 
-| Prop                  | Type                | Required | Description                                                          | Default   |
-| --------------------- | ------------------- | -------- | -------------------------------------------------------------------- | --------- |
-| **`label`**           | string              | no       | Sets the title of the step                                           | ''        |
-| **`description`**     | string              | no       | Provides extra info about the step                                   | ''        |
-| **`icon`**            | React.ComponentType | no       | Custom icon to overwrite the default numerical indicator of the step | undefined |
-| **`isCompletedStep`** | boolean             | no       | Individually control each step state, defaults to active step        | undefined |
+| Prop                  | Type                 | Required | Description                                                                                       | Default   |
+| --------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------- | --------- |
+| **`label`**           | string               | no       | Sets the title of the step                                                                        | ''        |
+| **`description`**     | string               | no       | Provides extra info about the step                                                                | ''        |
+| **`icon`**            | React.ComponentType  | no       | Custom icon to overwrite the default numerical indicator of the step                              | undefined |
+| **`isCompletedStep`** | boolean              | no       | Individually control each step state, defaults to active step                                     | undefined |
+| **`checkIcon`**       | React.ComponentType  | no       | Allows you to provide a custom check icon that will override the one provided to Steps            | undefined |
+| **`state`**           | 'loading' \| 'error' | no       | Let's you set the state in a specific Step, if defined it will override the one provided to Steps | undefined |

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 <br />
 <br />
 
-[![MIT License](https://badgen.net/github/license/jeanverster/chakra-ui-steps "MIT License")](LICENSE.md)
-[![npm - chakra-ui-steps](https://img.shields.io/npm/v/chakra-ui-steps "chakra-ui-steps npm")](https://www.npmjs.com/package/chakra-ui-steps)
+[![MIT License](https://badgen.net/github/license/jeanverster/chakra-ui-steps 'MIT License')](LICENSE.md)
+[![npm - chakra-ui-steps](https://img.shields.io/npm/v/chakra-ui-steps 'chakra-ui-steps npm')](https://www.npmjs.com/package/chakra-ui-steps)
 [![bundle size - chakra-ui-steps](https://badgen.net/bundlephobia/min/chakra-ui-steps)](https://bundlephobia.com/result?p=chakra-ui-steps)
 [![bundle size - chakra-ui-steps](https://badgen.net/bundlephobia/minzip/chakra-ui-steps)](https://bundlephobia.com/result?p=chakra-ui-steps)
-[![Total Downloads - chakra-ui-steps](https://badgen.net/npm/dt/chakra-ui-steps?color=blue "chakra-ui-steps npm downloads")](https://www.npmjs.com/package/chakra-ui-steps)
+[![Total Downloads - chakra-ui-steps](https://badgen.net/npm/dt/chakra-ui-steps?color=blue 'chakra-ui-steps npm downloads')](https://www.npmjs.com/package/chakra-ui-steps)
 
 ![screenshot](https://i.imgur.com/B9zbJEa.gif)
 
@@ -42,8 +42,8 @@ npm i chakra-ui-steps
 In order to get started you will need to extend the default Chakra theme with the provided `StepsStyleConfig` object, like so:
 
 ```jsx
-import { ChakraProvider, extendTheme } from "@chakra-ui/react";
-import { StepsStyleConfig as Steps } from "chakra-ui-steps";
+import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+import { StepsStyleConfig as Steps } from 'chakra-ui-steps';
 
 const theme = extendTheme({
   components: {
@@ -65,7 +65,7 @@ Once that's done you should be good to go!
 ### Basic Example
 
 ```jsx
-import { Step, Steps, useSteps } from "chakra-ui-steps";
+import { Step, Steps, useSteps } from 'chakra-ui-steps';
 
 const content = (
   <Flex py={4}>
@@ -74,9 +74,9 @@ const content = (
 );
 
 const steps = [
-  { label: "Step 1", content },
-  { label: "Step 2", content },
-  { label: "Step 3", content },
+  { label: 'Step 1', content },
+  { label: 'Step 2', content },
+  { label: 'Step 3', content },
 ];
 
 export const StepsExample = () => {
@@ -85,7 +85,7 @@ export const StepsExample = () => {
   });
 
   return (
-    <Flex flexDir="column" width="100%">
+    <Flex flexDir='column' width='100%'>
       <Steps activeStep={activeStep}>
         {steps.map(({ label, content }) => (
           <Step label={label} key={label}>
@@ -95,23 +95,23 @@ export const StepsExample = () => {
       </Steps>
       {activeStep === steps.length ? (
         <Flex p={4}>
-          <Button mx="auto" size="sm" onClick={reset}>
+          <Button mx='auto' size='sm' onClick={reset}>
             Reset
           </Button>
         </Flex>
       ) : (
-        <Flex width="100%" justify="flex-end">
+        <Flex width='100%' justify='flex-end'>
           <Button
             isDisabled={activeStep === 0}
             mr={4}
             onClick={prevStep}
-            size="sm"
-            variant="ghost"
+            size='sm'
+            variant='ghost'
           >
             Prev
           </Button>
-          <Button size="sm" onClick={nextStep}>
-            {activeStep === steps.length - 1 ? "Finish" : "Next"}
+          <Button size='sm' onClick={nextStep}>
+            {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
           </Button>
         </Flex>
       )}
@@ -140,7 +140,7 @@ steps;
 The default styles for each part can be found <a href="https://github.com/jeanverster/chakra-ui-steps/blob/main/src/theme/index.ts" target="_blank">here</a>. Below is an example of how you might change the stroke width of the icons:
 
 ```js
-import { StepsStyleConfig } from "chakra-ui-steps";
+import { StepsStyleConfig } from 'chakra-ui-steps';
 
 const CustomSteps = {
   ...StepsStyleConfig,
@@ -150,7 +150,7 @@ const CustomSteps = {
       icon: {
         ...StepsStyleConfig.baseStyle(props).icon,
         // your custom styles here
-        strokeWidth: "1px",
+        strokeWidth: '1px',
       },
     };
   },

--- a/README.md
+++ b/README.md
@@ -188,5 +188,6 @@ const theme = extendTheme({
 | **`description`**     | string               | no       | Provides extra info about the step                                                                | ''        |
 | **`icon`**            | React.ComponentType  | no       | Custom icon to overwrite the default numerical indicator of the step                              | undefined |
 | **`isCompletedStep`** | boolean              | no       | Individually control each step state, defaults to active step                                     | undefined |
+| **`isKeepError`**     | boolean              | no       | Individually control if each step should keep showing the error state                             | undefined |
 | **`checkIcon`**       | React.ComponentType  | no       | Allows you to provide a custom check icon that will override the one provided to Steps            | undefined |
 | **`state`**           | 'loading' \| 'error' | no       | Let's you set the state in a specific Step, if defined it will override the one provided to Steps | undefined |

--- a/chakra-ui-steps/src/components/Step/index.tsx
+++ b/chakra-ui-steps/src/components/Step/index.tsx
@@ -18,6 +18,7 @@ export interface StepProps extends HTMLChakraProps<'li'> {
   label?: string | React.ReactNode;
   description?: string;
   icon?: React.ComponentType<any>;
+  state?: 'loading' | 'error';
   checkIcon?: React.ComponentType<any>;
   isCompletedStep?: boolean;
 }
@@ -38,6 +39,7 @@ export const Step = forwardRef<StepProps, 'li'>(
       children,
       description,
       icon,
+      state,
       checkIcon,
       index,
       isCompletedStep,
@@ -114,7 +116,9 @@ export const Step = forwardRef<StepProps, 'li'>(
             <chakra.div
               __css={stepIconContainer}
               aria-current={isCurrentStep ? 'step' : undefined}
-              data-invalid={dataAttr(isCurrentStep && isError)}
+              data-invalid={dataAttr(
+                isCurrentStep && (isError || state === 'error')
+              )}
               data-highlighted={dataAttr(isCompletedStep)}
               data-clickable={dataAttr(clickable)}
             >
@@ -122,8 +126,8 @@ export const Step = forwardRef<StepProps, 'li'>(
                 <StepIcon
                   {...{
                     index,
-                    isError,
-                    isLoading,
+                    isError: isError || state === 'error',
+                    isLoading: isLoading || state === 'loading',
                     isCurrentStep,
                     isCompletedStep,
                   }}

--- a/chakra-ui-steps/src/components/Step/index.tsx
+++ b/chakra-ui-steps/src/components/Step/index.tsx
@@ -18,6 +18,7 @@ export interface StepProps extends HTMLChakraProps<'li'> {
   label?: string | React.ReactNode;
   description?: string;
   icon?: React.ComponentType<any>;
+  checkIcon?: React.ComponentType<any>;
   isCompletedStep?: boolean;
 }
 
@@ -37,6 +38,7 @@ export const Step = forwardRef<StepProps, 'li'>(
       children,
       description,
       icon,
+      checkIcon,
       index,
       isCompletedStep,
       isCurrentStep,
@@ -50,7 +52,7 @@ export const Step = forwardRef<StepProps, 'li'>(
       isError,
       isLoading,
       isLabelVertical,
-      checkIcon,
+      checkIcon: defaultCheckIcon,
       onClickStep,
       clickable,
       setWidths,
@@ -73,7 +75,7 @@ export const Step = forwardRef<StepProps, 'li'>(
 
     React.useEffect(() => {
       if (containerRef && containerRef.current && setWidths) {
-        setWidths(prev => {
+        setWidths((prev) => {
           if (prev.length === stepCount) {
             return [containerRef.current?.offsetWidth || 0];
           }
@@ -126,7 +128,7 @@ export const Step = forwardRef<StepProps, 'li'>(
                     isCompletedStep,
                   }}
                   icon={icon}
-                  checkIcon={checkIcon}
+                  checkIcon={checkIcon ?? defaultCheckIcon}
                 />
               </AnimatePresence>
             </chakra.div>

--- a/chakra-ui-steps/src/components/Step/index.tsx
+++ b/chakra-ui-steps/src/components/Step/index.tsx
@@ -21,6 +21,7 @@ export interface StepProps extends HTMLChakraProps<'li'> {
   state?: 'loading' | 'error';
   checkIcon?: React.ComponentType<any>;
   isCompletedStep?: boolean;
+  isKeepError?: boolean;
 }
 
 // Props which shouldn't be passed to to the Step component from the user
@@ -45,6 +46,7 @@ export const Step = forwardRef<StepProps, 'li'>(
       isCompletedStep,
       isCurrentStep,
       isLastStep,
+      isKeepError,
       label,
       ...styleProps
     } = props as FullStepProps;
@@ -116,9 +118,14 @@ export const Step = forwardRef<StepProps, 'li'>(
           >
             <chakra.div
               __css={stepIconContainer}
-              aria-current={isCurrentStep ? 'step' : undefined}
+              aria-current={
+                (hasVisited && isKeepError) || isCurrentStep
+                  ? 'step'
+                  : undefined
+              }
               data-invalid={dataAttr(
-                isCurrentStep && (isError || state === 'error')
+                ((hasVisited && isKeepError) || isCurrentStep) &&
+                  (isError || state === 'error')
               )}
               data-highlighted={dataAttr(isCompletedStep)}
               data-clickable={dataAttr(clickable)}
@@ -131,6 +138,7 @@ export const Step = forwardRef<StepProps, 'li'>(
                     isLoading: isLoading || state === 'loading',
                     isCurrentStep,
                     isCompletedStep,
+                    isKeepError,
                   }}
                   icon={icon}
                   checkIcon={checkIcon ?? defaultCheckIcon}

--- a/chakra-ui-steps/src/components/StepIcon/index.tsx
+++ b/chakra-ui-steps/src/components/StepIcon/index.tsx
@@ -9,6 +9,7 @@ interface StepIconProps {
   isCurrentStep?: boolean;
   isError?: boolean;
   isLoading?: boolean;
+  isKeepError?: boolean;
   icon?: React.ComponentType<any>;
   index: number;
   checkIcon?: React.ComponentType<any>;
@@ -35,6 +36,7 @@ export const StepIcon = forwardRef<StepIconProps, 'div'>((props, ref) => {
     isCurrentStep,
     isError,
     isLoading,
+    isKeepError,
     icon: CustomIcon,
     index,
     checkIcon: CustomCheckIcon,
@@ -48,9 +50,10 @@ export const StepIcon = forwardRef<StepIconProps, 'div'>((props, ref) => {
     ...label,
   };
 
-  const Icon = React.useMemo(() => (CustomIcon ? CustomIcon : null), [
-    CustomIcon,
-  ]);
+  const Icon = React.useMemo(
+    () => (CustomIcon ? CustomIcon : null),
+    [CustomIcon]
+  );
 
   const Check = React.useMemo(
     () => (CustomCheckIcon ? CustomCheckIcon : CheckIcon),
@@ -59,6 +62,16 @@ export const StepIcon = forwardRef<StepIconProps, 'div'>((props, ref) => {
 
   return React.useMemo(() => {
     if (isCompletedStep) {
+      if (isError && isKeepError) {
+        return (
+          <AnimatedCloseIcon
+            key="icon"
+            color="white"
+            {...animationConfig}
+            style={icon}
+          />
+        );
+      }
       return (
         <MotionFlex key="check-icon" {...animationConfig}>
           <Check color="white" style={icon} />

--- a/chakra-ui-steps/stories/Steps.stories.tsx
+++ b/chakra-ui-steps/stories/Steps.stories.tsx
@@ -246,6 +246,64 @@ export const WithStates = (): JSX.Element => {
   );
 };
 
+const statesSteps: StateValue[] = ['loading', 'error', undefined];
+
+export const WithPerStepState = (): JSX.Element => {
+  const { nextStep, prevStep, reset, activeStep } = useSteps({
+    initialStep: 0,
+  });
+
+  const { size } = useConfigContext();
+
+  return (
+    <>
+      <Steps size={size} activeStep={activeStep}>
+        {steps.map(({ label }, index) => (
+          <Step label={label} key={label} state={statesSteps[index]}>
+            <Content my={6} index={index} />
+          </Step>
+        ))}
+      </Steps>
+      {activeStep === 3 ? (
+        <ResetPrompt onReset={reset} />
+      ) : (
+        <StepButtons
+          {...{ nextStep, prevStep }}
+          prevDisabled={activeStep === 0}
+        />
+      )}
+    </>
+  );
+};
+
+export const WithKeepErrorState = (): JSX.Element => {
+  const { nextStep, prevStep, reset, activeStep } = useSteps({
+    initialStep: 0,
+  });
+
+  const { size } = useConfigContext();
+
+  return (
+    <>
+      <Steps size={size} activeStep={activeStep}>
+        {steps.map(({ label }, index) => (
+          <Step label={label} key={label} state="error" isKeepError>
+            <Content my={6} index={index} />
+          </Step>
+        ))}
+      </Steps>
+      {activeStep === 3 ? (
+        <ResetPrompt onReset={reset} />
+      ) : (
+        <StepButtons
+          {...{ nextStep, prevStep }}
+          prevDisabled={activeStep === 0}
+        />
+      )}
+    </>
+  );
+};
+
 const iconSteps = [
   { label: 'Login', icon: FiUser },
   { label: 'Verification', icon: FiClipboard },
@@ -290,6 +348,32 @@ export const CustomCheckIcon = (): JSX.Element => {
       <Steps size={size} checkIcon={FiCheckCircle} activeStep={activeStep}>
         {steps.map(({ label }, index) => (
           <Step label={label} key={label}>
+            <Content my={6} index={index} />
+          </Step>
+        ))}
+      </Steps>
+      {activeStep === 3 ? (
+        <ResetPrompt onReset={reset} />
+      ) : (
+        <StepButtons
+          {...{ nextStep, prevStep }}
+          prevDisabled={activeStep === 0}
+        />
+      )}
+    </>
+  );
+};
+
+export const CustomPerStepCheckIcon = (): JSX.Element => {
+  const { nextStep, prevStep, reset, activeStep } = useSteps({
+    initialStep: 0,
+  });
+  const { size } = useConfigContext();
+  return (
+    <>
+      <Steps size={size} checkIcon={FiCheckCircle} activeStep={activeStep}>
+        {iconSteps.map(({ label, icon }, index) => (
+          <Step label={label} key={label} checkIcon={icon}>
             <Content my={6} index={index} />
           </Step>
         ))}


### PR DESCRIPTION
Thanks for creating this lovely library; it's excellent! I started using it today and need a way to set the `checkIcon` and `state` at each step. I'm using it for a consent dialog and want to show the error state for a single step if a consent is declined. And maybe even using a different icon. Let me know what you think.