### PR TITLE
Chore: Widen the framer motion peer dependency range

### DIFF
--- a/chakra-ui-steps/package.json
+++ b/chakra-ui-steps/package.json
@@ -42,7 +42,7 @@
     "@chakra-ui/react": "^2.0.0",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
-    "framer-motion": "^7.0.0",
+    "framer-motion": ">=4.0.0",
     "react": "^18.0.0"
   },
   "husky": {


### PR DESCRIPTION
Framer-motion is at the time of writing at `10.12.4`. This PR widens the peer dependency range to equal that of chakra-ui, any version greater than `4.0`.