### PR TITLE
Fix/exports default order

### DIFF
--- a/chakra-ui-steps/package.json
+++ b/chakra-ui-steps/package.json
@@ -15,8 +15,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/chakra-ui-steps.mjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/chakra-ui-steps.mjs"
       },
       "require": "./dist/chakra-ui-steps.umd.js"
     }


### PR DESCRIPTION
Fixes the package export map order by placing types before the default condition to satisfy bundler/loader expectations and resolve “Module not found: Default condition should be last one.”

<img width="563" height="118" alt="image" src="https://github.com/user-attachments/assets/6b5336c8-27bd-4f41-bd6d-fdf591db71fa" />
